### PR TITLE
feat: Add javascript-use-prettier flag

### DIFF
--- a/.github/workflows/reusable-super-linter.yaml
+++ b/.github/workflows/reusable-super-linter.yaml
@@ -14,7 +14,6 @@ name: Lint all the codes
 #
 
 on:
-
   workflow_call:
     inputs:
       devops-only:
@@ -26,14 +25,17 @@ on:
         description: A regex to exclude files from linting
         required: false
         type: string
+      javascript-use-prettier:
+        description: Set Javascript Default Style to Prettier and disable standard linter
+        required: false
+        type: boolean
 
 permissions:
-  contents: read            # git permissions to repo pull/push
-  statuses: write           # read/write to repo custom statuses and checks
+  contents: read # git permissions to repo pull/push
+  statuses: write # read/write to repo custom statuses and checks
 
 jobs:
   super-lint:
-
     name: Super-Linter
 
     runs-on: ubuntu-latest
@@ -103,6 +105,20 @@ jobs:
             echo "VALIDATE_RUBY=false";
             echo "VALIDATE_PHP=false";
             echo "VALIDATE_CSHARP=false";
+
+          } >> $GITHUB_ENV
+
+      # Set Javascript Default Style to Prettier and disable standard linter
+      # Default style is "standard"
+      - name: Set Javascript Default Style
+        if: ${{ inputs.javascript-use-prettier == true }}
+        run: |
+          # shellcheck disable=2086
+          {
+            echo "JAVASCRIPT_DEFAULT_STYLE=prettier";
+            echo "VALIDATE_JAVASCRIPT_STANDARD=false";
+
+            echo "Using prettier javascript style and disabling Javascript standard linter"
 
           } >> $GITHUB_ENV
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ The GitHub [Super-Linter](https://github.com/marketplace/actions/super-linter) p
 
 ## Features of this custom Super-Linter example
 
-- All the features of [Super-Linter](https://github.com/marketplace/actions/super-linter) in a *Reusable* Workflow.
+- All the features of [Super-Linter](https://github.com/marketplace/actions/super-linter) in a _Reusable_ Workflow.
 - Bonus: Optionally turn off non-DevOps linters (CSS, JS, HTML, etc.) when you want to ignore code (in my case it's to ignore sample code I stick in DevOps projects).
 - Bonus: I added Job steps to correctly determine which branch to diff files with (in the case of having multiple release branches).
 - Bonus: Lints only changed files on a PR, but lints all files on merge to main (or any release) branch.
 
-## How to reuse this example as a *Reusable* Workflow
+## How to reuse this example as a _Reusable_ Workflow
 
 1. Fork this repository for you to customize your linters in a single location for your org/projects.
 2. Add a new workflow to all your other repositories and paste in this YAML to call the central-repos reusable workflow.
@@ -22,7 +22,6 @@ The GitHub [Super-Linter](https://github.com/marketplace/actions/super-linter) p
 name: Lint Code Base
 
 on:
-
   # run anytime a PR is merged to main or a direct push to main
   push:
     branches: [main]
@@ -37,7 +36,6 @@ concurrency:
 
 jobs:
   call-super-linter:
-
     name: Call Super-Linter
 
     permissions:
@@ -54,13 +52,17 @@ jobs:
     ### Optional settings examples
 
     # with:
-      ### For a DevOps-focused repository. Prevents some code-language linters from running
-      ### defaults to false
-      # devops-only: false
+    ### For a DevOps-focused repository. Prevents some code-language linters from running
+    ### defaults to false
+    ### devops-only: false
 
-      ### A regex to exclude files from linting
-      ### defaults to empty
-      # filter-regex-exclude: html/.*
+    ### A regex to exclude files from linting
+    ### defaults to empty
+    ### filter-regex-exclude: html/.*
+
+    ### If you're using the 'prettier' javascript style with eslint linting set this to true
+    ### defaults to false
+    ### javascript-use-prettier: true
 ```
 
 ## How to run Super-Linter locally

--- a/templates/call-super-linter.yaml
+++ b/templates/call-super-linter.yaml
@@ -3,7 +3,6 @@
 name: Lint Code Base
 
 on:
-
   # run anytime a PR is merged to main or a direct push to main
   push:
     branches: [main]
@@ -18,7 +17,6 @@ concurrency:
 
 jobs:
   call-super-linter:
-
     name: Call Super-Linter
 
     permissions:
@@ -35,10 +33,14 @@ jobs:
     ### Optional settings examples
 
     # with:
-      ### For a DevOps-focused repository. Prevents some code-language linters from running
-      ### defaults to false
-      # devops-only: false
+    ### For a DevOps-focused repository. Prevents some code-language linters from running
+    ### defaults to false
+    ### devops-only: false
 
-      ### A regex to exclude files from linting
-      ### defaults to empty
-      # filter-regex-exclude: html/.*
+    ### A regex to exclude files from linting
+    ### defaults to empty
+    ### filter-regex-exclude: html/.*
+
+    ### If you're using the 'prettier' javascript style with eslint linting set this to true
+    ### defaults to false
+    ### javascript-use-prettier: true


### PR DESCRIPTION
Add the javascript-use-prettier flag.

This flag makes the linter expect 'prettier' style javascript formatting and disables the 'standard' javascript linter.

Use with "javascript-use-prettier: true" in the calling workflow file.